### PR TITLE
feat: add multi-message context with Redis persistence

### DIFF
--- a/matvey-template.toml
+++ b/matvey-template.toml
@@ -66,8 +66,16 @@ Start your responses always with a random emoji and a line break.
 Always insert random fact about something in the reply
 """
 is_admin = true
+save_messages = true
+# Enable conversation context (default: true)
+context_enabled = true
+# Maximum number of messages to include in context (default: 10)
+max_context_messages = 10
 
 [[chats.allowed]]
 id = -1001000000777
 who = "Very important chat group"
 save_messages = true
+# Optional: disable context for this chat
+# context_enabled = false
+

--- a/src/bot_handler.py
+++ b/src/bot_handler.py
@@ -118,6 +118,7 @@ async def dump_set_prompt(message: types.Message, command: types.CommandObject):
 
 
 @router.message(
+    config.filter_command_not_disabled_for_chat,
     config.filter_chat_allowed,
     Command(commands=['new_chat']),
 )
@@ -131,7 +132,6 @@ async def handle_new_chat(message: types.Message):
         f'Starting fresh conversation.'
     )
     await react(success=True, message=message)
-
 
 
 @router.message(
@@ -370,6 +370,7 @@ async def handle_text_message(message: types.Message):
     save_messages = chat_config.save_messages
     context_enabled = chat_config.context_enabled
     
+    # Define tag for potential use in context building and message saving
     tag = f'matvey-3000:history:{config.me_strip_lower}:{message.chat.id}'
     
     if save_messages:
@@ -419,9 +420,8 @@ async def handle_text_message(message: types.Message):
             system_prompt=system_prompt,
             max_tokens=4000,
         )
-        # Add current message if not already in context
-        if not messages_to_send or messages_to_send[-1][1] != message.text:
-            messages_to_send.append(('user', message.text))
+        # Always add current message (it was just saved to Redis)
+        messages_to_send.append(('user', message.text))
     else:
         # Fallback to thread-based context
         messages_to_send = [

--- a/src/bot_handler.py
+++ b/src/bot_handler.py
@@ -118,6 +118,23 @@ async def dump_set_prompt(message: types.Message, command: types.CommandObject):
 
 
 @router.message(
+    config.filter_chat_allowed,
+    Command(commands=['new_chat']),
+)
+async def handle_new_chat(message: types.Message):
+    """Clear conversation history and start fresh."""
+    tag = f'matvey-3000:history:{config.me_strip_lower}:{message.chat.id}'
+    deleted_count = message_store.clear_conversation_history(tag)
+    
+    await message.reply(
+        f'🔄 Conversation history cleared! ({deleted_count} messages removed)\n'
+        f'Starting fresh conversation.'
+    )
+    await react(success=True, message=message)
+
+
+
+@router.message(
     config.filter_command_not_disabled_for_chat,
     config.filter_chat_allowed,
     Command(commands=['pic']),
@@ -349,9 +366,13 @@ After you recap everything, highlight three most outstanding facts or points fro
 
 @router.message(F.text, config.filter_chat_allowed)
 async def handle_text_message(message: types.Message):
-    save_messages = config[message.chat.id].save_messages
+    chat_config = config[message.chat.id]
+    save_messages = chat_config.save_messages
+    context_enabled = chat_config.context_enabled
+    
+    tag = f'matvey-3000:history:{config.me_strip_lower}:{message.chat.id}'
+    
     if save_messages:
-        tag = f'matvey-3000:history:{config.me_strip_lower}:{message.chat.id}'
         msg = StoredChatMessage.from_tg_message(message)
         message_store.save(tag, msg)
 
@@ -361,31 +382,52 @@ async def handle_text_message(message: types.Message):
     if len(args) == 1:
         return
 
+    # Determine if we should respond
+    should_respond = False
+    
+    # Check if this is a reply thread (backward compatibility)
     message_chain = extract_message_chain(message, bot.id)
-    # print(message_chain)
-    if not any(role == 'assistant' for role, _ in message_chain):
-        # this seems... twisted. Need to double-check
-        if len(message_chain) > 1 and random.random() < 0.95:
-            # vv wtf is this comment?
-            # logging.info('podpizdnut mode fired')
-            return
-
-    if len(message_chain) == 1 and message.chat.id < 0:
-        if not any(config.me in x for x in args):
-            # nobody mentioned me, so I shut up
-            return
+    has_bot_in_thread = any(role == 'assistant' for role, _ in message_chain)
+    
+    if has_bot_in_thread:
+        # Bot is part of the thread, respond
+        should_respond = True
+    elif len(message_chain) > 1 and random.random() < 0.95:
+        # Thread without bot, mostly ignore
+        return
+    elif message.chat.id < 0:
+        # Group chat - only respond if mentioned
+        if any(config.me in x for x in args):
+            should_respond = True
     else:
-        # we are either in private messages,
-        # or there's a continuation of a thread
-        pass
+        # Private chat - always respond
+        should_respond = True
+    
+    if not should_respond:
+        return
 
-    messages_to_send = [
-        config.prompt_tuple_for_chat(message.chat.id),
-        *message_chain,
-    ]
-
-    # print('chain of', len(message_chain))
-    # print('in chat', message.chat.id)
+    # Build context for LLM
+    system_prompt = config.prompt_tuple_for_chat(message.chat.id)
+    
+    if context_enabled and save_messages:
+        # Use Redis-based conversation history
+        max_context = chat_config.max_context_messages
+        messages_to_send = message_store.build_context_messages(
+            key=tag,
+            limit=max_context,
+            bot_username=config.me_strip_lower,
+            system_prompt=system_prompt,
+            max_tokens=4000,
+        )
+        # Add current message if not already in context
+        if not messages_to_send or messages_to_send[-1][1] != message.text:
+            messages_to_send.append(('user', message.text))
+    else:
+        # Fallback to thread-based context
+        messages_to_send = [
+            system_prompt,
+            *message_chain,
+        ]
 
     await message.chat.do('typing')
 

--- a/src/config.py
+++ b/src/config.py
@@ -20,6 +20,8 @@ class ChatConfig:
     save_messages: bool = False
     summary_enabled: bool = False
     disabled_commands: list[str] | None = None
+    context_enabled: bool = True
+    max_context_messages: int = 10
 
     @classmethod
     def just_no(cls, chat_id, provider, disabled_commands):
@@ -33,6 +35,8 @@ class ChatConfig:
             summary_enabled=False,
             disabled_commands=disabled_commands,
             who="i don't know who",
+            context_enabled=False,
+            max_context_messages=0,
         )
 
 
@@ -96,6 +100,8 @@ class Config:
                 save_messages=chat.get('save_messages', False),
                 summary_enabled=chat.get('summary_enabled', False),
                 disabled_commands=chat.get('disabled_commands', []),
+                context_enabled=chat.get('context_enabled', True),
+                max_context_messages=chat.get('max_context_messages', 10),
             )
             for chat in config['chats']['allowed']
         }

--- a/src/config.py
+++ b/src/config.py
@@ -79,6 +79,7 @@ class Config:
         '/sum',
         '/samari',
         '/sosum',
+        '/new_chat',
     ]
 
     @classmethod

--- a/src/message_store.py
+++ b/src/message_store.py
@@ -192,5 +192,3 @@ class MessageStore:
         
         context.extend(included_history)
         return context
-
-

--- a/tests/test_extract_message_chain.py
+++ b/tests/test_extract_message_chain.py
@@ -1,4 +1,9 @@
 import pytest
+import sys
+from pathlib import Path
+
+# Add src directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
 
 from aiogram import types
 from bot_handler import extract_message_chain

--- a/tests/test_message_store.py
+++ b/tests/test_message_store.py
@@ -1,0 +1,311 @@
+import pytest
+import sys
+from pathlib import Path
+from unittest.mock import Mock, MagicMock
+from dataclasses import asdict
+
+# Add src directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
+
+from message_store import MessageStore, StoredChatMessage
+
+
+@pytest.fixture
+def mock_redis():
+    """Mock Redis connection."""
+    redis_mock = MagicMock()
+    redis_mock.lrange.return_value = []
+    redis_mock.llen.return_value = 0
+    redis_mock.rpush.return_value = 1
+    redis_mock.delete.return_value = 1
+    return redis_mock
+
+
+@pytest.fixture
+def message_store(mock_redis):
+    """Create MessageStore with mocked Redis."""
+    store = MessageStore.__new__(MessageStore)
+    store.redis_conn = mock_redis
+    return store
+
+
+@pytest.fixture
+def sample_messages():
+    """Create sample chat messages."""
+    return [
+        StoredChatMessage(
+            chat_name="Test Chat",
+            from_username="user1",
+            from_full_name="User One",
+            timestamp=1000,
+            text="Hello bot!",
+        ),
+        StoredChatMessage(
+            chat_name="Test Chat",
+            from_username="testbot",
+            from_full_name="BOT",
+            timestamp=1001,
+            text="Hello! How can I help?",
+        ),
+        StoredChatMessage(
+            chat_name="Test Chat",
+            from_username="user1",
+            from_full_name="User One",
+            timestamp=1002,
+            text="What's the weather?",
+        ),
+        StoredChatMessage(
+            chat_name="Test Chat",
+            from_username="testbot",
+            from_full_name="BOT",
+            timestamp=1003,
+            text="I don't have weather data.",
+        ),
+    ]
+
+
+class TestStoredChatMessage:
+    """Test StoredChatMessage dataclass."""
+
+    def test_serialize_deserialize(self):
+        """Test message serialization and deserialization."""
+        msg = StoredChatMessage(
+            chat_name="Test",
+            from_username="user",
+            from_full_name="User Name",
+            timestamp=12345,
+            text="Test message",
+        )
+        
+        serialized = msg.serialize()
+        deserialized = StoredChatMessage.deserialize(serialized)
+        
+        assert deserialized.chat_name == msg.chat_name
+        assert deserialized.from_username == msg.from_username
+        assert deserialized.from_full_name == msg.from_full_name
+        assert deserialized.timestamp == msg.timestamp
+        assert deserialized.text == msg.text
+
+    def test_str_representation(self):
+        """Test string representation of message."""
+        msg = StoredChatMessage(
+            chat_name="Test",
+            from_username="user",
+            from_full_name="User Name",
+            timestamp=12345,
+            text="Hello",
+        )
+        
+        result = str(msg)
+        assert "User Name <user>" in result
+        assert "[at 12345]" in result
+        assert "Hello" in result
+
+
+class TestMessageStore:
+    """Test MessageStore functionality."""
+
+    def test_save_message(self, message_store, mock_redis, sample_messages):
+        """Test saving a message to Redis."""
+        msg = sample_messages[0]
+        key = "test:key"
+        
+        message_store.save(key, msg)
+        
+        mock_redis.rpush.assert_called_once_with(key, msg.serialize())
+
+    def test_save_message_with_cutoff(self, message_store, mock_redis, sample_messages):
+        """Test that messages are trimmed when exceeding CUTOFF."""
+        msg = sample_messages[0]
+        key = "test:key"
+        
+        # Simulate list length exceeding CUTOFF
+        mock_redis.llen.return_value = 2001
+        
+        message_store.save(key, msg)
+        
+        mock_redis.ltrim.assert_called_once()
+
+    def test_fetch_messages(self, message_store, mock_redis, sample_messages):
+        """Test fetching messages from Redis."""
+        key = "test:key"
+        serialized = [msg.serialize() for msg in sample_messages]
+        mock_redis.lrange.return_value = serialized
+        
+        result = message_store.fetch_messages(key, limit=10, raw=False)
+        
+        assert len(result) == len(sample_messages)
+        assert all(isinstance(msg, StoredChatMessage) for msg in result)
+        mock_redis.lrange.assert_called_once_with(key, -10, -1)
+
+    def test_fetch_messages_raw(self, message_store, mock_redis, sample_messages):
+        """Test fetching raw messages from Redis."""
+        key = "test:key"
+        serialized = [msg.serialize() for msg in sample_messages]
+        mock_redis.lrange.return_value = serialized
+        
+        result = message_store.fetch_messages(key, limit=5, raw=True)
+        
+        assert result == serialized
+
+    def test_fetch_conversation_history(self, message_store, mock_redis, sample_messages):
+        """Test fetching conversation history as (role, text) tuples."""
+        key = "test:key"
+        bot_username = "testbot"
+        serialized = [msg.serialize() for msg in sample_messages]
+        mock_redis.lrange.return_value = serialized
+        
+        result = message_store.fetch_conversation_history(key, limit=10, bot_username=bot_username)
+        
+        expected = [
+            ('user', 'Hello bot!'),
+            ('assistant', 'Hello! How can I help?'),
+            ('user', "What's the weather?"),
+            ('assistant', "I don't have weather data."),
+        ]
+        assert result == expected
+
+    def test_clear_conversation_history(self, message_store, mock_redis):
+        """Test clearing conversation history."""
+        key = "test:key"
+        mock_redis.llen.return_value = 42
+        
+        deleted_count = message_store.clear_conversation_history(key)
+        
+        assert deleted_count == 42
+        mock_redis.delete.assert_called_once_with(key)
+
+    def test_build_context_messages_empty_history(self, message_store, mock_redis):
+        """Test building context with no history."""
+        key = "test:key"
+        system_prompt = ('system', 'You are a helpful bot')
+        mock_redis.lrange.return_value = []
+        
+        result = message_store.build_context_messages(
+            key=key,
+            limit=10,
+            bot_username="testbot",
+            system_prompt=system_prompt,
+            max_tokens=4000,
+        )
+        
+        assert result == [system_prompt]
+
+    def test_build_context_messages_with_history(self, message_store, mock_redis, sample_messages):
+        """Test building context with conversation history."""
+        key = "test:key"
+        system_prompt = ('system', 'You are a helpful bot')
+        bot_username = "testbot"
+        serialized = [msg.serialize() for msg in sample_messages]
+        mock_redis.lrange.return_value = serialized
+        
+        result = message_store.build_context_messages(
+            key=key,
+            limit=10,
+            bot_username=bot_username,
+            system_prompt=system_prompt,
+            max_tokens=4000,
+        )
+        
+        # Should include system prompt + all messages
+        assert len(result) >= 1
+        assert result[0] == system_prompt
+        # Check that history is included
+        assert any(text == 'Hello bot!' for role, text in result)
+
+    def test_build_context_messages_filters_none_text(self, message_store, mock_redis):
+        """Test that messages with None or empty text are filtered out."""
+        key = "test:key"
+        system_prompt = ('system', 'You are a helpful bot')
+        
+        # Create messages with None and empty text
+        messages = [
+            StoredChatMessage("Chat", "user1", "User", 1000, "Valid message"),
+            StoredChatMessage("Chat", "user1", "User", 1001, None),
+            StoredChatMessage("Chat", "user1", "User", 1002, ""),
+            StoredChatMessage("Chat", "user1", "User", 1003, "Another valid"),
+        ]
+        serialized = [msg.serialize() for msg in messages]
+        mock_redis.lrange.return_value = serialized
+        
+        result = message_store.build_context_messages(
+            key=key,
+            limit=10,
+            bot_username="testbot",
+            system_prompt=system_prompt,
+            max_tokens=4000,
+        )
+        
+        # Should only include system prompt + 2 valid messages
+        assert len(result) == 3
+        assert result[0] == system_prompt
+        assert ('user', 'Valid message') in result
+        assert ('user', 'Another valid') in result
+
+    def test_build_context_messages_respects_token_limit(self, message_store, mock_redis):
+        """Test that context building respects token limits."""
+        key = "test:key"
+        system_prompt = ('system', 'You are a helpful bot')
+        
+        # Create messages with long text
+        long_text = "word " * 1000  # Very long message
+        messages = [
+            StoredChatMessage("Chat", "user1", "User", 1000, long_text),
+            StoredChatMessage("Chat", "user1", "User", 1001, long_text),
+            StoredChatMessage("Chat", "user1", "User", 1002, "Short message"),
+        ]
+        serialized = [msg.serialize() for msg in messages]
+        mock_redis.lrange.return_value = serialized
+        
+        result = message_store.build_context_messages(
+            key=key,
+            limit=10,
+            bot_username="testbot",
+            system_prompt=system_prompt,
+            max_tokens=100,  # Very low token limit
+        )
+        
+        # Should include system prompt and maybe one short message
+        # but not all the long messages
+        assert len(result) <= 3
+        assert result[0] == system_prompt
+
+    def test_build_context_messages_prioritizes_recent(self, message_store, mock_redis):
+        """Test that most recent messages are prioritized when token limit is reached."""
+        key = "test:key"
+        system_prompt = ('system', 'Short prompt')
+        
+        # Create messages - most recent should be prioritized
+        messages = [
+            StoredChatMessage("Chat", "user1", "User", 1000, "Old message"),
+            StoredChatMessage("Chat", "user1", "User", 1001, "Middle message"),
+            StoredChatMessage("Chat", "user1", "User", 1002, "Recent message"),
+        ]
+        serialized = [msg.serialize() for msg in messages]
+        mock_redis.lrange.return_value = serialized
+        
+        result = message_store.build_context_messages(
+            key=key,
+            limit=10,
+            bot_username="testbot",
+            system_prompt=system_prompt,
+            max_tokens=50,  # Limited tokens
+        )
+        
+        # Most recent message should be included
+        texts = [text for role, text in result]
+        if len(result) > 1:  # If any history was included
+            assert "Recent message" in texts
+
+    def test_fetch_stats(self, message_store, mock_redis):
+        """Test fetching statistics about stored messages."""
+        pattern = "test:*"
+        mock_redis.keys.return_value = [b"test:chat1", b"test:chat2"]
+        mock_redis.type.return_value = b"list"
+        mock_redis.llen.side_effect = [10, 20]
+        
+        result = message_store.fetch_stats(pattern)
+        
+        assert len(result) == 2
+        assert ("test:chat1", 10) in result
+        assert ("test:chat2", 20) in result

--- a/tests/test_personal_config_parser.py
+++ b/tests/test_personal_config_parser.py
@@ -1,6 +1,11 @@
 import pytest
+import sys
+from pathlib import Path
 import textwrap
 import warnings
+
+# Add src directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
 
 from config import Config
 


### PR DESCRIPTION
- Extended MessageStore with conversation history methods
- Added fetch_conversation_history, clear_conversation_history, and build_context_messages
- Updated ChatConfig with context_enabled and max_context_messages settings
- Refactored handle_text_message to use Redis-based context instead of thread-only
- Added /new-chat command to clear conversation history
- Implemented token limit awareness to prevent exceeding model limits
- Maintained backward compatibility with thread-based replies